### PR TITLE
Set http headers from laravel request

### DIFF
--- a/src/AgentServiceProvider.php
+++ b/src/AgentServiceProvider.php
@@ -26,7 +26,7 @@ class AgentServiceProvider extends ServiceProvider {
     {
         $this->app['agent'] = $this->app->share(function ($app)
         {
-            return new Agent;
+            return new Agent($app['request']->server->all());
         });
     }
 


### PR DESCRIPTION
sets the http headers on mobile detect from the laravel request headers,
so headers wont be taken directly from global $_SERVER.

Also, this change enable the use of ```Agent``` in laravel application unit tests.