### PR TITLE
Using Contract interface instead of string alias

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -3,9 +3,10 @@
 namespace Jenssegers\Agent;
 
 use BadMethodCallException;
+use Jenssegers\Agent\Contracts\Agent as AgentContract;
 use Mobile_Detect;
 
-class Agent extends Mobile_Detect {
+class Agent extends Mobile_Detect implements AgentContract {
 
     /**
      * List of desktop devices.
@@ -138,6 +139,8 @@ class Agent extends Mobile_Detect {
     /**
      * Get accept languages.
      *
+     * @param  string|null  $acceptLanguage
+     *
      * @return array
      */
     public function languages($acceptLanguage = null)
@@ -177,6 +180,7 @@ class Agent extends Mobile_Detect {
      *
      * @param  array  $rules
      * @param  null   $userAgent
+     *
      * @return string
      */
     protected function findDetectionRulesAgainstUA(array $rules, $userAgent = null)
@@ -196,6 +200,8 @@ class Agent extends Mobile_Detect {
     /**
      * Get the browser name.
      *
+     * @param  string|null  $userAgent
+     *
      * @return string
      */
     public function browser($userAgent = null)
@@ -214,7 +220,8 @@ class Agent extends Mobile_Detect {
     /**
      * Get the platform name.
      *
-     * @param  string $userAgent
+     * @param  string|null  $userAgent
+     *
      * @return string
      */
     public function platform($userAgent = null)
@@ -231,7 +238,8 @@ class Agent extends Mobile_Detect {
     /**
      * Get the device name.
      *
-     * @param  string $userAgent
+     * @param  string|null  $userAgent
+     *
      * @return string
      */
     public function device($userAgent = null)
@@ -250,11 +258,9 @@ class Agent extends Mobile_Detect {
     /**
      * Check if the device is a desktop computer.
      *
-     * @param  string $userAgent   deprecated
-     * @param  array  $httpHeaders deprecated
      * @return bool
      */
-    public function isDesktop($userAgent = null, $httpHeaders = null)
+    public function isDesktop()
     {
         return ! $this->isMobile() && ! $this->isTablet() && ! $this->isRobot();
     }
@@ -262,11 +268,9 @@ class Agent extends Mobile_Detect {
     /**
      * Check if the device is a mobile phone.
      *
-     * @param  string $userAgent   deprecated
-     * @param  array  $httpHeaders deprecated
      * @return bool
      */
-    public function isPhone($userAgent = null, $httpHeaders = null)
+    public function isPhone()
     {
         return $this->isMobile() && ! $this->isTablet();
     }
@@ -274,7 +278,8 @@ class Agent extends Mobile_Detect {
     /**
      * Get the robot name.
      *
-     * @param  string $userAgent
+     * @param  string|null  $userAgent
+     *
      * @return string
      */
     public function robot($userAgent = null)
@@ -292,7 +297,8 @@ class Agent extends Mobile_Detect {
     /**
      * Check if device is a robot.
      *
-     * @param  string  $userAgent
+     * @param  string|null  $userAgent
+     *
      * @return bool
      */
     public function isRobot($userAgent = null)
@@ -316,7 +322,10 @@ class Agent extends Mobile_Detect {
     /**
      * Check the version of the given property in the User-Agent.
      *
-     * @inherit
+     * @param  string  $propertyName
+     * @param  string  $type
+     *
+     * @return string|float
      */
     public function version($propertyName, $type = self::VERSION_TYPE_STRING)
     {

--- a/src/AgentServiceProvider.php
+++ b/src/AgentServiceProvider.php
@@ -14,6 +14,17 @@ class AgentServiceProvider extends ServiceProvider {
     protected $defer = false;
 
     /**
+     * Register the service provider.
+     */
+    public function register()
+    {
+        $this->app->singleton('Jenssegers\Agent\Contracts\Agent', function ($app) {
+            return new Agent($app['request']->server->all());
+        });
+        $this->app->singleton('agent', 'Jenssegers\Agent\Contracts\Agent');
+    }
+
+    /**
      * Bootstrap the application events.
      */
     public function boot()
@@ -21,15 +32,11 @@ class AgentServiceProvider extends ServiceProvider {
         //
     }
 
-    /**
-     * Register the service provider.
-     */
-    public function register()
+    public function provides()
     {
-        $this->app['agent'] = $this->app->share(function ($app)
-        {
-            return new Agent($app['request']->server->all());
-        });
+        return [
+            'Jenssegers\Agent\Contracts\Agent',
+            'agent',
+        ];
     }
-
 }

--- a/src/Contracts/Agent.php
+++ b/src/Contracts/Agent.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Jenssegers\Agent\Contracts;
+
+use Mobile_Detect;
+
+interface Agent
+{
+    /**
+     * Set the HTTP Headers.
+     *
+     * @param  array  $httpHeaders
+     */
+    public function setHttpHeaders($httpHeaders = null);
+
+    /**
+     * Set the User-Agent to be used.
+     *
+     * @param  string|null  $userAgent
+     *
+     * @return string|null
+     */
+    public function setUserAgent($userAgent = null);
+
+    /**
+     * Get accept languages.
+     *
+     * @param  string|null  $acceptLanguage
+     *
+     * @return array
+     */
+    public function languages($acceptLanguage = null);
+
+    /**
+     * Get the browser name.
+     *
+     * @param  string|null  $userAgent
+     *
+     * @return string
+     */
+    public function browser($userAgent = null);
+
+    /**
+     * Get the platform name.
+     *
+     * @param  string|null  $userAgent
+     *
+     * @return string
+     */
+    public function platform($userAgent = null);
+
+    /**
+     * Get the device name.
+     *
+     * @param  string|null  $userAgent
+     *
+     * @return string
+     */
+    public function device($userAgent = null);
+
+    /**
+     * Check if the device is a desktop computer.
+     *
+     * @return bool
+     */
+    public function isDesktop();
+
+    /**
+     * Check if the device is a mobile phone.
+     *
+     * @return bool
+     */
+    public function isPhone();
+
+    /**
+     * This method checks for a certain property in the userAgent.
+     *
+     * @param  string        $key
+     * @param  string        $userAgent   deprecated
+     * @param  string        $httpHeaders deprecated
+     *
+     * @return bool|int|null
+     */
+    public function is($key, $userAgent = null, $httpHeaders = null);
+
+    /**
+     * Get the robot name.
+     *
+     * @param  string|null  $userAgent
+     *
+     * @return string
+     */
+    public function robot($userAgent = null);
+
+    /**
+     * Check if device is a robot.
+     *
+     * @param  string|null  $userAgent
+     *
+     * @return bool
+     */
+    public function isRobot($userAgent = null);
+
+    /**
+     * Check the version of the given property in the User-Agent.
+     *
+     * @param  string  $propertyName
+     * @param  string  $type
+     *
+     * @return string|float
+     */
+    public function version($propertyName, $type = Mobile_Detect::VERSION_TYPE_STRING);
+
+    /**
+     * Some detection rules are relative (not standard), because of the diversity of devices,
+     * vendors and their conventions in representing the User-Agent or the HTTP headers.
+     *
+     * @param  string       $regex
+     * @param  string|null  $userAgent
+     *
+     * @return bool
+     */
+    public function match($regex, $userAgent = null);
+}

--- a/src/Facades/Agent.php
+++ b/src/Facades/Agent.php
@@ -13,7 +13,7 @@ class Agent extends Facade {
      */
     protected static function getFacadeAccessor()
     {
-        return 'agent';
+        return 'Jenssegers\Agent\Contracts\Agent';
     }
 
 }


### PR DESCRIPTION
+ Using the Contract interface to inject the dependency in the constructor (like Controller or Middleware).
+ Fixing doc comments
+ Removing the deprecated arguments from `isPhone()` & `isDesktop()` methods.