### PR TITLE
Distinction between Opera and Opera Mini

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -41,6 +41,7 @@ class Agent extends Mobile_Detect
      * @var array
      */
     protected static $additionalBrowsers = [
+        'Opera Mini' => 'Opera Mini',
         'Opera' => 'Opera|OPR',
         'Edge' => 'Edge',
         'UCBrowser' => 'UCBrowser',
@@ -68,6 +69,7 @@ class Agent extends Mobile_Detect
         'ChromeOS' => 'CrOS x86_64 [VER]',
 
         // Browsers
+        'Opera Mini' => 'Opera Mini/[VER]',
         'Opera' => [' OPR/[VER]', 'Opera Mini/[VER]', 'Version/[VER]', 'Opera [VER]'],
         'Netscape' => 'Netscape/[VER]',
         'Mozilla' => 'rv:[VER]',


### PR DESCRIPTION
Added distinction between **Opera**  and **Opera Mini**. Even if Opera Mini is an Opera's browser it stays very different from other Opera browsers because it's a proxy browser and it has its own behaviors when rendering web pages or while processing Javascript.

This change will allow to target specifically Opera Mini on mobile without affecting the regular Opera browser.

P.S: Now when you download Opera Mini on a mobile, you can switch between Opera  and Opera Mini by choosing the data saving mode, so you have one app which could be Opera or Opera Mini according to your settings.The User-Agent changes too as you are using the app as Opera or as Opera Mini

Referring to the issue #70 
More about the difference between Opera and Opera Mini [here](http://www.opera.com/blogs/india/2015/05/which-is-the-best-opera-browser-for-android-phones/)