### PR TITLE
Update Laravel installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ composer require jenssegers/agent
 Laravel (optional)
 ------------------
 
-Add the service provider in `app/config/app.php`:
+Add the service provider in `config/app.php`:
 
 ```php
 Jenssegers\Agent\AgentServiceProvider::class,
 ```
 
-And add the Agent alias to `app/config/app.php`:
+And add the Agent alias to `config/app.php`:
 
 ```php
 'Agent' => Jenssegers\Agent\Facades\Agent::class,


### PR DESCRIPTION
Point the config file to add the service provider class and alias in the correct directory
`config\app.php` is the correct directory as of Laravel 5.x