### PR TITLE
Remove illuminate/support as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "^4.0|^5.0",
         "mobiledetect/mobiledetectlib": "^2.7.6",
         "jaybizzle/crawler-detect": "^1.2"
     },
@@ -37,6 +36,9 @@
                 "Agent": "Jenssegers\\Agent\\Facades\\Agent"
             }
         }
+    },
+    "suggests": {
+        "illuminate/support": "^4.0|^5.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true


### PR DESCRIPTION
I removed the `illuminate/support` package and the tests all still pass. I don't use laravel, but this seems like a package that does something I was already about to do. The main issue I have is that the `illuminate/support` package provides global functions that conflict with some I've created.

![wweaver_wills-mbp____git_agent__zsh_](https://user-images.githubusercontent.com/1482976/32624577-a35c4230-c557-11e7-8100-1d8fd1306252.png)
