### PR TITLE
Improve Laravel service provider

### DIFF
--- a/src/AgentServiceProvider.php
+++ b/src/AgentServiceProvider.php
@@ -19,7 +19,7 @@ class AgentServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton('agent', function ($app) {
-            return new Agent($app['request']->server->all());
+            return new Agent($app['request']->server());
         });
 
         $this->app->alias('agent', Agent::class);

--- a/src/AgentServiceProvider.php
+++ b/src/AgentServiceProvider.php
@@ -11,7 +11,7 @@ class AgentServiceProvider extends ServiceProvider
      *
      * @var bool
      */
-    protected $defer = false;
+    protected $defer = true;
 
     /**
      * Bootstrap the application events.
@@ -29,5 +29,17 @@ class AgentServiceProvider extends ServiceProvider
         $this->app->singleton('agent', function ($app) {
             return new Agent($app['request']->server->all());
         });
+
+        $this->app->alias('agent', Agent::class);
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return ['agent', Agent::class];
     }
 }

--- a/src/AgentServiceProvider.php
+++ b/src/AgentServiceProvider.php
@@ -14,14 +14,6 @@ class AgentServiceProvider extends ServiceProvider
     protected $defer = true;
 
     /**
-     * Bootstrap the application events.
-     */
-    public function boot()
-    {
-        //
-    }
-
-    /**
      * Register the service provider.
      */
     public function register()


### PR DESCRIPTION
- [Deferred](https://laravel.com/docs/5.5/providers#deferred-providers) the provider since we only register service binding.
- Remove unused `boot()` method.
- Use the Laravel built-in `server()` method on the Laravel request instance, instead of its internal dependence i.e. Symfony Request component.