### PR TITLE
Use modern wording for Mac and macOS

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -14,7 +14,7 @@ class Agent extends Mobile_Detect
      * @var array
      */
     protected static $additionalDevices = [
-        'Macintosh' => 'Macintosh',
+        'Mac' => 'Macintosh',
     ];
 
     /**
@@ -25,7 +25,7 @@ class Agent extends Mobile_Detect
     protected static $additionalOperatingSystems = [
         'Windows' => 'Windows',
         'Windows NT' => 'Windows NT',
-        'OS X' => 'Mac OS X',
+        'macOS' => 'Mac OS X',
         'Debian' => 'Debian',
         'Ubuntu' => 'Ubuntu',
         'Macintosh' => 'PPC',
@@ -63,7 +63,7 @@ class Agent extends Mobile_Detect
         // Operating systems
         'Windows' => 'Windows NT [VER]',
         'Windows NT' => 'Windows NT [VER]',
-        'OS X' => 'OS X [VER]',
+        'macOS' => 'OS X [VER]',
         'BlackBerryOS' => ['BlackBerry[\w]+/[VER]', 'BlackBerry.*Version/[VER]', 'Version/[VER]'],
         'AndroidOS' => 'Android [VER]',
         'ChromeOS' => 'CrOS x86_64 [VER]',


### PR DESCRIPTION
This PR is intended to use the modern terminology used by Apple for its computers (Mac) and for its OS now called "macOS" instead of "OS X"