### PR TITLE
Fixed bug when testing browser version for Opera or IE #138

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -347,6 +347,8 @@ class Agent extends Mobile_Detect
 
         foreach ($all as $rules) {
             foreach ($rules as $key => $value) {
+                if (is_array($value)) $value = implode('|', $value);
+
                 if (empty($merged[$key])) {
                     $merged[$key] = $value;
                 } elseif (is_array($merged[$key])) {

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -320,6 +320,10 @@ class Agent extends Mobile_Detect
             $properties[$propertyName] = (array) $properties[$propertyName];
 
             foreach ($properties[$propertyName] as $propertyMatchString) {
+                if (is_array($propertyMatchString)) {
+                    $propertyMatchString = implode("|", $propertyMatchString);
+                }
+
                 $propertyPattern = str_replace('[VER]', self::VER, $propertyMatchString);
 
                 // Identify and extract the version.
@@ -347,10 +351,6 @@ class Agent extends Mobile_Detect
 
         foreach ($all as $rules) {
             foreach ($rules as $key => $value) {
-                if (is_array($value)) {
-                    $value = implode('|', $value);
-                }
-
                 if (empty($merged[$key])) {
                     $merged[$key] = $value;
                 } elseif (is_array($merged[$key])) {

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -347,7 +347,9 @@ class Agent extends Mobile_Detect
 
         foreach ($all as $rules) {
             foreach ($rules as $key => $value) {
-                if (is_array($value)) $value = implode('|', $value);
+                if (is_array($value)) {
+                    $value = implode('|', $value);
+                }
 
                 if (empty($merged[$key])) {
                     $merged[$key] = $value;

--- a/tests/AgentTest.php
+++ b/tests/AgentTest.php
@@ -222,6 +222,11 @@ class AgentTest extends TestCase
             $platform = $agent->platform();
             $this->assertEquals($version, $agent->version($platform), $ua);
         }
+
+        foreach ($this->browsers as $ua => $browser) {
+            $agent->setUserAgent('FAKE');
+            $this->assertFalse($agent->version($browser));
+        }
     }
 
     public function testIsMethods()


### PR DESCRIPTION
https://github.com/jenssegers/agent/issues/138

This fixes an issue with detecting the browser version if the mobile detect library returns an array of parameters instead of a string. 

There may be a better way to handle this so that the preg_match in the version method doesnt have duplicated items in it, but this should work to prevent any errors if it gets that far.