### PR TITLE
Fix Travis CI build

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "jaybizzle/crawler-detect": "^1.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0|^6.0|^7.0|^8.0",
+        "phpunit/phpunit": "^5.0|^6.0|^7.0",
         "php-coveralls/php-coveralls": "^2.1"
     },
     "autoload": {


### PR DESCRIPTION
# Changed log
- Fix Travis CI build.
- When using `PHPUnit 8.x` verson, it will output following message:

```
PHP Fatal error:  Declaration of BasicTest::setUp() must be compatible with PHPUnit\Framework\TestCase::setUp(): void in /data/agent/vendor/mobiledetect/mobiledetectlib/tests/BasicsTest.php on line 510
```

To resolve issue, removing `PHPUnit 8.x` version definition on `composer.json`.