### PR TITLE
Trust the decision of isDesktop from CloudFront when available

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -263,6 +263,14 @@ class Agent extends Mobile_Detect
      */
     public function isDesktop($userAgent = null, $httpHeaders = null)
     {
+        // Check specifically for cloudfront headers if the useragent === 'Amazon CloudFront'
+        if ($this->getUserAgent() === 'Amazon CloudFront') {
+            $cfHeaders = $this->getCfHeaders();
+            if(array_key_exists('HTTP_CLOUDFRONT_IS_DESKTOP_VIEWER', $cfHeaders)) {
+                return $cfHeaders['HTTP_CLOUDFRONT_IS_DESKTOP_VIEWER'] === 'true';
+            }
+        }
+
         return !$this->isMobile($userAgent, $httpHeaders) && !$this->isTablet($userAgent, $httpHeaders) && !$this->isRobot($userAgent);
     }
 


### PR DESCRIPTION
Trust the decision of isDesktop from CloudFront when available, save considerable CPU cycles and reduce confusion.