### PR TITLE
BrowserVersions support for Edge on Android (EdgA) & Edge on iOS (EdgiOS)

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -71,7 +71,7 @@ class Agent extends Mobile_Detect
         'Netscape' => 'Netscape/[VER]',
         'Mozilla' => 'rv:[VER]',
         'IE' => ['IEMobile/[VER];', 'IEMobile [VER]', 'MSIE [VER];', 'rv:[VER]'],
-        'Edge' => ['Edge/[VER]', 'Edg/[VER]'],
+        'Edge' => ['Edge/[VER]', 'Edg/[VER]', 'EdgA/[VER]', 'EdgiOS/[VER]'],
         'Vivaldi' => 'Vivaldi/[VER]',
         'Coc Coc' => 'coc_coc_browser/[VER]',
     ];

--- a/tests/AgentTest.php
+++ b/tests/AgentTest.php
@@ -69,6 +69,8 @@ class AgentTest extends TestCase
         'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.29 Safari/537.36 Edg/79.0.309.18' => '79.0.309.18',
         'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43' => '1.2.490.43',
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) coc_coc_browser/86.0.180 Chrome/80.0.3987.180 Safari/537.36' => '86.0.180',
+        'Mozilla/5.0 (Linux; Android 8.0; Pixel XL Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.0 Mobile Safari/537.36 EdgA/41.1.35.1' => '41.1.35.1',
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_2 like Mac OS X) AppleWebKit/603.2.4 (KHTML, like Gecko) Mobile/14F89 Safari/603.2.4 EdgiOS/41.1.35.1' => '41.1.35.1'
     ];
 
     private $operatingSystemVersions = [


### PR DESCRIPTION
Currently BrowserVersions support is broken for EdgeA/EdgiOS and returns false, this will fix it ..