### PR TITLE
fix - package broken due to dependecy code change

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -137,10 +137,7 @@ class Agent extends Mobile_Detect
 
     public static function getOperatingSystems()
     {
-        return static::mergeRules(
-            static::$operatingSystems,
-            static::$additionalOperatingSystems
-        );
+        return static::$operatingSystems;
     }
 
     public static function getPlatforms()


### PR DESCRIPTION
Hi.

Surely due to this change 

https://github.com/serbanghita/Mobile-Detect/commit/ba9281b06937a01afdb72ae90064bd6ba4d35435

the package is broken as we add to "getOperatingSystems" a list of not really mobile ones.

Hope this helps.

cc https://github.com/jenssegers/agent/issues/207