### PR TITLE
Fixed incompatibility with Mobile-Detect v2.8.43

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -106,6 +106,32 @@ class Agent extends Mobile_Detect
         return $rules;
     }
 
+
+    /**
+     * Method gets the mobile detection rules. This method is used for the magic methods $detect->is*().
+     *
+     * Since this function should only return rules that can detect mobile devices, do not pollute it
+     * with non-mobile stuff.
+     *
+     * @return array All the rules (but not extended).
+     */
+    public static function getMobileDetectionRules()
+    {
+        static $rules;
+
+        if (!$rules) {
+            $rules = array_merge(
+                parent::getPhoneDevices(),
+                parent::getTabletDevices(),
+                parent::getOperatingSystems(),
+                parent::getBrowsers()
+            );
+        }
+
+        return $rules;
+
+    }
+
     public function getRules()
     {
         if ($this->detectionType === static::DETECTION_TYPE_EXTENDED) {


### PR DESCRIPTION
The problem is caused by the ->is*() function, aka the "Extended" features confusing the core function of detecting mobile devices. I think the better way to fix it is to overwrite the getMobileDetectionRules() and make sure it won't be polluted. In this case the extended features still work while not sacrifice the ability to detect mobile devices.